### PR TITLE
Added JSON decoding

### DIFF
--- a/php/vanilla/index.php
+++ b/php/vanilla/index.php
@@ -6,6 +6,8 @@ if ($_SERVER['REQUEST_METHOD']!=='POST'){
   die();
 }
 
+$_POST = json_decode(file_get_contents('php://input'), true);
+
 if (is_null($_POST['deviceId'])){
   header("HTTP/1.0 204 No Content");
   die();


### PR DESCRIPTION
Hi Nicholas! As mentioned in my post in the Sigfox AnswerHub (http://sigfox.cloud.answerhub.com/questions/275/downlink-not-working.html) I was having problems with the Downlink and could not receive any data in my Akeru board. 
I did some tests to figure out the problem and found out that the $_POST was arriving "empty" and it would die() at line 6.

It turns out that $_POST is an array that is only populated if you send the POST body in URL encoded format. PHP does not parse JSON by itself automatically and hence does not populate the $_POST array.

Now I can receive the "cafecafecafecafe" in my Akeru board.
